### PR TITLE
[Feature Require] Change font file path to sd:/luma/

### DIFF
--- a/sysmodules/rosalina/source/draw.c
+++ b/sysmodules/rosalina/source/draw.c
@@ -46,10 +46,10 @@ static RecursiveLock lock;
 
 #if ONLY_CN_FONTLIB != 0
 static u8 fontbin[0x599C0];
-char *fontlibpath = "/unifont_cn.bin";
+char *fontlibpath = "/luma/unifont_cn.bin";
 #else
 static u8 fontbin[0x1EFAC0];
-char *fontlibpath = "/unifont_full.bin";
+char *fontlibpath = "/luma/unifont_full.bin";
 #endif
 
 void ReadFont2Mem(){


### PR DESCRIPTION
I with some people in straysoul's group don't think it's a good idea to push font file to the root.
By the way, we have received someone carelessly deleted the font file in the root and caused the problem.
Wish it can be changed to luma directory(sd:/luma).

我和火狐群的一些人认为将字库文件放在根目录里不是件好事。
其次，已经有人因误删根目录下的字库文件而出现问题。
希望能将字库读取位置改为"sd:/luma/"

---

By the way, the current version can't show chinese with full font and we don't know the reason. hope it can be fixed.

顺带一提，新版本的Full字库无法正常显示，原因未知，希望能得到解决。